### PR TITLE
unbound: new ipv4 address of ntp.nic.cz

### DIFF
--- a/net/unbound/files/unbound.defaults
+++ b/net/unbound/files/unbound.defaults
@@ -4,7 +4,7 @@ if [ "$(uci get -q dhcp.@dnsmasq[0].port || echo 53)" = 53 ] ; then
 	uci set dhcp.@dnsmasq[0].port=0
 fi
 # Make sure we can set time for resolution to work, before the resolution works.
-uci show system.ntp.server | grep -q '217\.31\.205\.226' || uci add_list system.ntp.server=217.31.205.226
+uci show system.ntp.server | grep -q '217\.31\.202\.100' || uci add_list system.ntp.server=217.31.202.100
 # Also, when we have turned the dnsmasq DNS off, ask dnsmasq to advertise us as DNS server
 uci show dhcp | sed -ne 's/^dhcp\.//;s/=dhcp$//p' | while read INTERFACE ; do
 	# If the interface has an IP address. Otherwise, just ignore it.


### PR DESCRIPTION
The server ntp.nic.cz has changed its IPv4 address. Hope the new one will be more stable.

BTW: the old address 217.31.205.226 still has reverse record of ntp.nic.cz.