### PR TITLE
unbound: add support for remote control configuration

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads

--- a/net/unbound/files/unbound-config
+++ b/net/unbound/files/unbound-config
@@ -34,5 +34,10 @@ config unbound server
 config unbound python
     #list python_script "/etc/unbound/ubmodule-tst.py"
 
+config unbound remote_control
+    option control_enable no
+    list control_interface 0.0.0.0
+    list control_interface ::0
+
 config unbound includes
     #list include_path "/etc/unbound/unbound-part.conf"

--- a/net/unbound/files/unbound-init
+++ b/net/unbound/files/unbound-init
@@ -13,7 +13,9 @@ EOF
 
 add_section() {
     section="$1"
-    echo "$section:" >> "$CONFIGFILE"
+    name="${2:-$1}"
+
+    echo "$name:" >> "$CONFIGFILE"
 }
 
 add_inculde() {
@@ -99,7 +101,14 @@ init_unbound() {
     set_multiple_parameters python_script python-script
 
     #Remote Control
-    add_section remote-control
+    add_section remote_control remote-control
+    set_parameter control_enable control-enable no
+    set_multiple_parameters control_interface control-interface
+    set_parameter control_port control-port 8953
+    set_quoted_parameter server_key_file server-key-file "/etc/unbound/unbound_server.key"
+    set_quoted_parameter server_cert_file server-cert-file "/etc/unbound/unbound_server.pem"
+    set_quoted_parameter control_key_file control-key-file "/etc/unbound/unbound_control.pem"
+    set_quoted_parameter control_cert_file control-cert-file "/etc/unbound/unbound_control.pem"
 
     #Includes
     config_list_foreach includes include_path add_inculde


### PR DESCRIPTION
This patch set adds support for remote control configuration in Unbound.

- Remote control interface is disabled by default.
- The server/client TLS certificates are not generated automatically.