### PR TITLE
kresd: support local config file

### DIFF
--- a/net/knot-resolver/files/kresd.init
+++ b/net/knot-resolver/files/kresd.init
@@ -109,6 +109,11 @@ load_uci_config_common() {
 			done
 		fi
 	fi
+
+	# local config
+	if [ -e "/etc/kresd/config" ]; then
+		cat /etc/kresd/config >> $CONFIGFILE
+	fi
 }
 
 load_uci_config_kresd() {


### PR DESCRIPTION
There's currently no way to change the kresd config file without
modifying the init script (changes which will be overwritten
each time kresd is updated).

This patch adds support for local configs (similarly to how
dnsmasq allows both /etc/dnsmasq.conf and uci config).