### PR TITLE
Enable Pulseaudio in mpd-full

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -52,7 +52,7 @@ $(call Package/mpd/Default)
   TITLE+= (full)
   DEPENDS+= \
 	+libaudiofile +BUILD_PATENTED:libfaad2 +libffmpeg +libid3tag \
-	+libmms +libogg +libsndfile +libvorbis +libupnp
+	+libmms +libogg +libsndfile +libvorbis +libupnp +pulseaudio-daemon
   PROVIDES:=mpd
   VARIANT:=full
 endef
@@ -127,7 +127,7 @@ CONFIGURE_ARGS += \
 	--disable-mpg123 \
 	--disable-openal \
 	--disable-opus \
-	--disable-pulse \
+	--enable-pulse \
 	--disable-sidplay \
 	--disable-solaris-output \
 	--disable-sqlite \
@@ -153,7 +153,7 @@ CONFIGURE_VARS += \
 	$(if $(CONFIG_BUILD_PATENTED),MAD_CFLAGS="$(TARGET_CFLAGS)") \
 	$(if $(CONFIG_BUILD_PATENTED),MAD_LIBS="$(TARGET_LDFLAGS) -lmad") \
 
-TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib $(if $(ICONV_FULL),-liconv)
+TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib,-rpath-link=$(STAGING_DIR)/usr/lib/pulseaudio $(if $(ICONV_FULL),-liconv)
 
 ifeq ($(BUILD_VARIANT),full)
 


### PR DESCRIPTION
Changes based on
https://wiki.openwrt.org/doc/howtobuild/build.mpd-full.pulse

Not tested as I didn't yet setup build environment.

Fixes #8 