### PR TITLE
foris: add localpath option for user-contributed non-foris content

### DIFF
--- a/cznic/foris/Makefile
+++ b/cznic/foris/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=foris
 PKG_VERSION:=78
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.labs.nic.cz/turris/foris.git

--- a/cznic/foris/files/lighttpd-dynamic-conf
+++ b/cznic/foris/files/lighttpd-dynamic-conf
@@ -12,6 +12,12 @@ config_get SESSION_TIMEOUT auth session_timeout ""
 # and for the sake of UX, training and leading slashes are trimmed
 SCRIPTNAME=$(echo "$SCRIPTNAME" | sed -e 's;\\;\\\\;g' | sed -e 's;/*$;;g' | sed -e 's;^/*;;g')
 
+LOCALPATH=""
+append_localpath() {
+	LOCALPATH="${LOCALPATH}|$(echo $1 | sed -e 's;\\;\\\\;g' | sed -e 's;/*$;;g' | sed -e 's;^/*;;g')"
+}
+config_list_foreach server localpath append_localpath
+
 EXTRA_FLAGS=""
 [ "$DEBUG" == "1" ] && EXTRA_FLAGS="$EXTRA_FLAGS -d"
 [ "$NOAUTH" == "1" ] && EXTRA_FLAGS="$EXTRA_FLAGS --noauth"
@@ -30,7 +36,7 @@ var.foris.bin = \"/usr/bin/foris\"\n\
 var.foris.flags = \"-s flup%EXTRA_FLAGS%\"\n\
 var.foris.scriptname = \"/%SCRIPTNAME%\"\n\
 \n\
-\$HTTP[\"url\"] =~ \"^\" + var.foris.scriptname + \"(?(?<!/)/|)(?!static|cgi-bin|luci-static|plugins)\" {\n\
+\$HTTP[\"url\"] =~ \"^\" + var.foris.scriptname + \"(?(?<!/)/|)(?!static|cgi-bin|luci-static|plugins%LOCALPATH%)\" {\n\
 	fastcgi.debug = 0\n\
 	fastcgi.server = (\n\
 		var.foris.scriptname => (\n\
@@ -58,4 +64,5 @@ for PLUGIN_PATH in $PLUGINS_DIR/*; do
 done
 
 echo -e "$TEMPLATE" | sed "s;%SCRIPTNAME%;$SCRIPTNAME;g" | sed "s;%FIX_ROOT_DISABLER%;$FIX_ROOT_DISABLER;g" \
-	| sed "s;%STATIC_PREFIX%;$STATIC_PREFIX;g" | sed "s;%EXTRA_FLAGS%;$EXTRA_FLAGS;g"
+	| sed "s;%STATIC_PREFIX%;$STATIC_PREFIX;g" | sed "s;%EXTRA_FLAGS%;$EXTRA_FLAGS;g" \
+	| sed "s;%LOCALPATH%;$LOCALPATH;g"


### PR DESCRIPTION
This patch adds possibility to set up some paths which are not routed
into the forris app. It's main purpose is to be able to support Let's
Encrypt web server ownership validation without changing the scriptname.

Example usage:

config config 'server'
	list localpath '.well-known'
	list localpath 'local-data'

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>