### PR TITLE
rescue-mode-omnia: Add emergency SSH shell

### DIFF
--- a/cznic/rescue-mode-omnia/Makefile
+++ b/cznic/rescue-mode-omnia/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rescue-mode-omnia
-PKG_VERSION:=2
+PKG_VERSION:=3
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)
 PKG_MAINTAINER:=Michal Hrusecky <michal.hrusecky@nic.cz>
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -40,6 +40,7 @@ define Package/$(PKG_NAME)/install
 
 	$(INSTALL_BIN) ./files/rescue.sh 	$(1)/bin/rescue.sh
 	$(INSTALL_BIN) ./files/init.sh 		$(1)/sbin/init
+	$(INSTALL_BIN) ./files/passwd 		$(1)/etc/passwd
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/cznic/rescue-mode-omnia/files/passwd
+++ b/cznic/rescue-mode-omnia/files/passwd
@@ -1,0 +1,1 @@
+root::0:0:root:/root:/bin/sh

--- a/cznic/rescue-mode-omnia/files/rescue.sh
+++ b/cznic/rescue-mode-omnia/files/rescue.sh
@@ -204,6 +204,21 @@ check_reset_clock () {
 	fi
 }
 
+rescue_shell() {
+	rainbow all ff0066 auto
+	d "Configuring switch LAN4 <-> eth0..."
+	swconfig dev switch0 vlan 1 set ports '4 5'
+	d "Setting IP..."
+	ip link set dev eth0 up
+	ip addr add dev eth0 192.168.1.1/24
+	d "Mounting /dev/pts..."
+	mount -t devpts devpts /dev/pts
+	d "Starting dropbear..."
+	rm -f /etc/dropbear/*
+	dropbear -R -B -E
+	d "Spawning local shell. Exit to reboot..."
+	setsid cttyhack sh
+}
 
 
 
@@ -236,6 +251,10 @@ case "$MODE" in
 	3)
 		d "Mode: Reflash..."
 		reflash
+		;;
+	4)
+		d "Mode: Rescue shell..."
+		rescue_shell
 		;;
 	*)
 		e "Invalid mode $MODE. Exit to shell."


### PR DESCRIPTION
Since there is no simply accessible serial console, it may be handy to
have a SSH recovery mode. This patch adds new rescue mode, activated by
holding the reset button until five LEDs are lit.

In this mode, the eth0 interface is set up using IP address
192.168.1.1/24 and the switch is configured so eth0 is interconnected
exclusivelly with the LAN4 port. Dropbear SSH server is started,
accepting root login without password.

This patch requires dropbear to be compiled inside the rescue image.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>