### PR TITLE
Resolver hotplug hook

### DIFF
--- a/net/knot-resolver/Makefile
+++ b/net/knot-resolver/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot-resolver
 PKG_VERSION=1.1.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.labs.nic.cz/knot/resolver.git

--- a/net/knot-resolver/files/kresd.init
+++ b/net/knot-resolver/files/kresd.init
@@ -126,6 +126,7 @@ load_uci_config_common() {
 				echo "policy:add(policy.all(policy.FORWARD('$SERVER')))">>$CONFIGFILE
 			done
 		fi
+		md5sum /tmp/resolv.conf.auto | cut -f1 -d\ >/tmp/resolv.conf.auto.last.md5
 	fi
 
 	# include custom kresd config

--- a/net/resolver-conf/Makefile
+++ b/net/resolver-conf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=resolver-conf
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -52,6 +52,8 @@ else
 endif
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/resolver-init $(1)/etc/init.d/resolver
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface/
+	$(INSTALL_BIN) ./files/resolver-reload $(1)/etc/hotplug.d/iface/40-resolver-reload
 endef
 
 define Package/$(PKG_NAME)/postinst

--- a/net/resolver-conf/files/resolver-reload
+++ b/net/resolver-conf/files/resolver-reload
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+MD5=$(md5sum /tmp/resolv.conf.auto | cut -f1 -d\ )
+PREVIOUS=$(cat /tmp/resolv.conf.auto.last.md5 || true)
+DO_FORWARD=$(uci -q get resolver.common.forward_upstream || echo 1)
+if /etc/init.d/resolver enabled && \
+   [ "$MD5" != "$PREVIOUS" ] && \
+   [ "$DO_FORWARD" = "1" ] ; then
+	/etc/init.d/resolver reload
+fi

--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.5.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
@@ -143,8 +143,6 @@ define Package/unbound/install
 	$(INSTALL_CONF) ./files/named.cache $(1)/etc/unbound/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/unbound-init $(1)/etc/init.d/unbound
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface/
-	$(CP) ./files/unbound-reload $(1)/etc/hotplug.d/iface/40-unbound-reload
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/unbound.defaults $(1)/etc/uci-defaults/unbound
 	$(INSTALL_DIR) $(1)/usr/share/unbound/

--- a/net/unbound/files/unbound-reload
+++ b/net/unbound/files/unbound-reload
@@ -1,6 +1,0 @@
-MD5=$(md5sum /tmp/resolv.conf.auto | cut -f1 -d\ )
-PREVIOUS=$(cat /tmp/resolv.conf.auto.last.md5 || true)
-DO_FORWARD=$(uci -q get unbound.server.forward_upstream || echo 1)
-if /etc/init.d/unbound enabled && [ "$MD5" != "$PREVIOUS" ] && [ "$DO_FORWARD" = "1" ] ; then
-	/etc/init.d/unbound reload
-fi


### PR DESCRIPTION
When an upstream interface get up later than a resolver, user preferred upstream forwarding of DNS queries is not followed. This PR fixes it both for `knot-resolver` and for `unbound` (where it used to work before migrating to `resolver-config` unified configuration).

Original bug report: https://forum.turris.cz/t/dns-forwarding-stops-working/1817

Not thoughtfully tested as my WAN starts early. But it should work.