### PR TITLE
lighttpd 1.4.44 and LuCI

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.44
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://download.lighttpd.net/lighttpd/releases-1.4.x
+PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
 PKG_MD5SUM:=adb66ca985651957feb209c91c55ebbf917d23630bfc3a216a2f70043c7b5422
 
 PKG_LICENSE:=BSD-3c

--- a/net/lighttpd/files/lighttpd.conf
+++ b/net/lighttpd/files/lighttpd.conf
@@ -10,7 +10,7 @@ server.pid-file             = "/var/run/lighttpd.pid"
 
 index-file.names            = ( "index.php", "index.html",
                                 "index.htm", "default.htm",
-                                "index.lighttpd.html" )
+                              )
 
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 
@@ -20,7 +20,7 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 #server.bind                 = "localhost"
 #server.tag                  = "lighttpd"
 #server.errorlog-use-syslog  = "enable"
-#server.network-backend      = "write"
+#server.network-backend      = "writev"
 
 # listen on IPv6
 $SERVER["socket"] == "[::]:80" {  }
@@ -31,6 +31,6 @@ $SERVER["socket"] == "[::]:80" {  }
 #dir-listing.encoding        = "utf-8"
 #server.dir-listing          = "enable"
 
-include       "/etc/lighttpd/mime.conf"
-include_shell "cat /etc/lighttpd/modules.d/*.load"
-include_shell "cat /etc/lighttpd/conf.d/*.conf"
+include "/etc/lighttpd/mime.conf"
+include "/etc/lighttpd/modules.d/*.load"
+include "/etc/lighttpd/conf.d/*.conf"

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -16,9 +16,7 @@ stop() {
 }
 
 restart() {
-	/usr/sbin/lighttpd -t -f /etc/lighttpd/lighttpd.conf || exit 1
-	ls /usr/lib/lighttpd/mod_alias.so || exit 1
-	ls /usr/lib/lighttpd/mod_cgi.so || exit 1
+	/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf || exit 1
 	stop
 	start
 }

--- a/net/lighttpd/patches/0001-mod_cgi-skip-local-redir-handling-if-to-self-2108.patch
+++ b/net/lighttpd/patches/0001-mod_cgi-skip-local-redir-handling-if-to-self-2108.patch
@@ -1,0 +1,28 @@
+--- a/src/mod_cgi.c
++++ b/src/mod_cgi.c
+@@ -529,9 +529,13 @@ static int cgi_demux_response(server *srv, handler_ctx *hctx) {
+ 
+ 					if (con->http_status >= 300 && con->http_status < 400) {
+ 						/*(con->parsed_response & HTTP_LOCATION)*/
++						size_t ulen = buffer_string_length(con->uri.path);
+ 						data_string *ds;
+ 						if (NULL != (ds = (data_string *) array_get_element(con->response.headers, "Location"))
+-						    && ds->value->ptr[0] == '/') {
++						    && ds->value->ptr[0] == '/'
++						    && (0 != strncmp(ds->value->ptr, con->uri.path->ptr, ulen)
++							|| (ds->value->ptr[ulen] != '\0' && ds->value->ptr[ulen] != '/' && ds->value->ptr[ulen] != '?'))
++						    && NULL == array_get_element(con->response.headers, "Set-Cookie")) {
+ 							if (++con->loops_per_request > 5) {
+ 								log_error_write(srv, __FILE__, __LINE__, "sb", "too many internal loops while processing request:", con->request.orig_uri);
+ 								con->http_status = 500; /* Internal Server Error */
+--- a/tests/docroot/www/cgi.pl
++++ b/tests/docroot/www/cgi.pl
+@@ -1,7 +1,7 @@
+ #!/usr/bin/env perl
+ 
+ if ($ENV{"QUERY_STRING"} eq "internal-redir") {
+-    print "Location: /cgi.pl\r\n\r\n";
++    print "Location: /cgi-pathinfo.pl/foo\r\n\r\n";
+     exit 0;
+ }
+ 


### PR DESCRIPTION
lighttpd 1.44 and LuCI

@miska please review for TurrisOS 3.5

The lighttpd mod_cgi patch is necessary for LuCI.

The other patches are not required, but the change to lighttpd.init reload would have caught the misconfiguration that some users on the forum reported tripping over when enabling rrdtool.