### PR TITLE
knot-resolver: (nitpick) use newer API for policy

### DIFF
--- a/net/knot-resolver/files/kresd.init
+++ b/net/knot-resolver/files/kresd.init
@@ -122,7 +122,7 @@ load_uci_config_common() {
 		local SERVERS
 		SERVERS=$(sed -ne 's/^nameserver \(.*\)/\1/p' /tmp/resolv.conf.auto | sort)
 		if [ "$SERVERS" ] ; then
-			echo "policy:add(policy.all(policy.FORWARD({">>$CONFIGFILE
+			echo "policy.add(policy.all(policy.FORWARD({">>$CONFIGFILE
 			for SERVER in $SERVERS ; do
 				echo "	'$SERVER',">>$CONFIGFILE
 			done


### PR DESCRIPTION
Since v1.1 there's a tiny change in the API.  Both are supported in
1.x, but I feel safer if we change it now.