### PR TITLE
Make separate log files for crontab and watchdog messages

### DIFF
--- a/admin/syslog-ng3/files/syslog-ng.conf
+++ b/admin/syslog-ng3/files/syslog-ng.conf
@@ -21,15 +21,55 @@ filter f_turris_iptables {
 	not match(".*turris[^:]*: .*" value(MESSAGE)) or not level(debug);
 };
 
+filter f_not_cron {
+	not program(".*cron.*");
+};
+
+filter f_cron {
+	program(".*cron.*");
+};
+
+filter f_not_watchdog {
+	not program(".*watchdog.*");
+};
+
+filter f_watchdog {
+	program(".*watchdog.*");
+};
+
 destination messages {
 	file("/var/log/messages" suppress(5) template("${ISODATE} ${PRIORITY} ${PROGRAM}[${PID}]: ${MSGONLY}\n") log_fifo_size(256));
+};
+
+destination cron {
+	file("/var/log/cron" suppress(5) template("${ISODATE} ${PRIORITY} ${PROGRAM}[${PID}]: ${MSGONLY}\n") log_fifo_size(256));
+};
+
+destination watchdog {
+	file("/var/log/watchdog" suppress(5) template("${ISODATE} ${PRIORITY} ${PROGRAM}[${PID}]: ${MSGONLY}\n") log_fifo_size(256));
 };
 
 log {
 	source(src);
 	source(kernel);
 	filter(f_turris_iptables);
+	filter(f_not_cron);
+	filter(f_not_watchdog);
 	destination(messages);
+};
+
+log {
+	source(src);
+	source(kernel);
+	filter(f_cron);
+	destination(cron);
+};
+
+log {
+	source(src);
+	source(kernel);
+	filter(f_watchdog);
+	destination(watchdog);
 };
 
 include "/etc/syslog-ng.d/";

--- a/utils/logrotate/files/logrotate.conf
+++ b/utils/logrotate/files/logrotate.conf
@@ -27,6 +27,22 @@ include /etc/logrotate.d
     rotate 1
 }
 
+/var/log/cron {
+    size=1M
+    delaycompress
+    postrotate
+	/etc/init.d/syslog-ng restart
+    endscript
+}
+
+/var/log/watchdog {
+    size=1M
+    delaycompress
+    postrotate
+	/etc/init.d/syslog-ng restart
+    endscript
+}
+
 /var/log/messages {
     size=1M
     delaycompress


### PR DESCRIPTION
Make separate files for crontab (/var/log/messages) and watchdog (/var/log/watchdog) logs, which quite spam default system log. Better options for maintaining system, in my opinion.