### PR TITLE
syslog-ng init script fix

### DIFF
--- a/admin/syslog-ng3/files/syslog-ng.init
+++ b/admin/syslog-ng3/files/syslog-ng.init
@@ -8,7 +8,8 @@ USE_PROCD=1
 start_service() {
 	[ -f /etc/syslog-ng.conf ] || return 1
 	procd_open_instance
-	procd_set_param command /usr/sbin/syslog-ng
+	procd_set_param command /usr/sbin/syslog-ng -F
+	procd_set_param respawn
 	procd_close_instance
 }
 


### PR DESCRIPTION
process monitored by procd should run in foreground
(without this change syslog-ng restart called by logrotate does not stop old syslog, but just starts additional one)
respawn enabled - so procd restarts syslog-ng when it crashes