### PR TITLE
openssh: UsePrivilegeSeparation is now deprecated

### DIFF
--- a/net/openssh/files/sshd.config
+++ b/net/openssh/files/sshd.config
@@ -94,7 +94,6 @@ config openssh
     #option PrintLastLog yes
     #option TCPKeepAlive yes
     #option UseLogin no
-    option UsePrivilegeSeparation sandbox
     #option PermitUserEnvironment no
     #option Compression delayed
     #option ClientAliveInterval 0

--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -110,7 +110,6 @@ handle_openssh_section(){
     set_parameter "$config" PrintLastLog PrintLastLog
     set_parameter "$config" TCPKeepAlive TCPKeepAlive
     set_parameter "$config" UseLogin UseLogin
-    set_parameter "$config" UsePrivilegeSeparation UsePrivilegeSeparation sandbox
     set_parameter "$config" PermitUserEnvironment PermitUserEnvironment
     set_parameter "$config" Compression Compression
     set_parameter "$config" ClientAliveInterval ClientAliveInterval

--- a/net/openssh/files/sshd.nuci.config
+++ b/net/openssh/files/sshd.nuci.config
@@ -84,7 +84,6 @@ config openssh
     #option PrintLastLog yes
     #option TCPKeepAlive yes
     #option UseLogin no
-    option UsePrivilegeSeparation sandbox
     #option PermitUserEnvironment no
     #option Compression delayed
     #option ClientAliveInterval 0


### PR DESCRIPTION
Remove UsePrivilegeSeparation setting as it is now deprecated in OpenSSH
7.5. It is enabled by default anyway.

https://www.openssh.com/txt/release-7.5