### PR TITLE
Foris: Add Content-Type to generated root content

### DIFF
--- a/cznic/foris/files/foris-root-cgi
+++ b/cznic/foris/files/foris-root-cgi
@@ -15,6 +15,8 @@ else
 fi
 
 cat << HTML
+Content-Type: text/html
+
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
Before the root page was served as a `.html` file: https://github.com/CZ-NIC/turris-os-packages/commit/e72d422319e6d814a07198787cf941fae8ea46ba#diff-271446ad865c93fbd6c102a33c33f4e1L75

We need the `Content-Type: text/html` for it to be processed properly by the browser and displayed as HTML, and not just as plain text.