### PR TITLE
modify init script to properly use rundir in /etc/config/resolver

### DIFF
--- a/net/knot-resolver/files/kresd.init
+++ b/net/knot-resolver/files/kresd.init
@@ -8,7 +8,6 @@ PROG=/usr/bin/kresd
 CONFIGFILE=/tmp/kresd.config
 ROOTKEYFILE=/etc/root.keys
 DEFAULT_RUNDIR=/tmp/kresd
-HINTS_CONFIG=$DEFAULT_RUNDIR/hints.tmp
 STATIC_DOMAINS=1
 DYNAMIC_DOMAINS=0
 
@@ -185,8 +184,19 @@ add_hostname_config() {
 	fi
 }
 
+modify_rundir() {
+        local rundir
+        local section="kresd"
+
+        # rundir
+        config_get rundir "$section" rundir "$DEFAULT_RUNDIR"
+	[ ! -d "$rundir" ] && mkdir -p "$rundir"
+        DEFAULT_RUNDIR="$rundir"
+	HINTS_CONFIG=$DEFAULT_RUNDIR/hints.tmp
+}
+
 load_uci_config_kresd() {
-	local addr config keyfile forks verbose rundir log_stderr log_stdout hostname_config
+	local addr config keyfile forks verbose log_stderr log_stdout hostname_config
 	local section="kresd"
 
 	# knot-resolver config
@@ -197,9 +207,7 @@ load_uci_config_kresd() {
 	procd_append_param command -f "$forks"
 
 	# rundir
-	config_get rundir "$section" rundir "$DEFAULT_RUNDIR"
-	[ ! -d "$rundir" ] && mkdir -p "$rundir"
-	procd_append_param command "$rundir"
+	procd_append_param command "$DEFAULT_RUNDIR"
 
 	# procd stdout/err logging
 	config_get_bool log_stderr "$section" log_stderr  1
@@ -231,6 +239,7 @@ run_instance() {
 	procd_open_instance
 	procd_set_param file /etc/config/resolver
 	procd_set_param command "$PROG"
+        modify_rundir
 	init_header
 	load_uci_config_kresd
 	load_uci_config_common
@@ -239,7 +248,7 @@ run_instance() {
 	  if ! ip -6 r s | grep -q '^default' &&\
 	     ping -c 1 api.turris.cz > /dev/null 2>&1 && \
 	     ! ping -6 -c 1 api.turris.cz > /dev/null 2>&1; then
-		echo "net.ipv6 = false" | socat - UNIX-CONNECT:$(sleep 5; ls -1 /tmp/kresd/tty/*) > /dev/null 2>&1
+		echo "net.ipv6 = false" | socat - UNIX-CONNECT:$(sleep 5; ls -1 $DEFAULT_RUNDIR/tty/*) > /dev/null 2>&1
 	  fi) &
 }
 


### PR DESCRIPTION
please add this changes to turris-os-repo it will properly use the 'rundir' specified in /etc/config/resolver in the /etc/init.d/knotd init script and also make the hints file and tty point to it.

it actually makes it possible to use a different rundir from /etc/config/resolver fully. At the moment the init script only uses rundir partially. I always had to also change the init script (apart from /etc/config/resolver) and manually change the DEFAULT_RUNDIR the and the tty file (which is hardcoded) to point to the new rundir. Problem my changes always got overwritten with each and every new release.