### PR TITLE
Apply change in makefile per upstream

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.47
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -172,6 +172,7 @@ $(eval $(call BuildPlugin,redirect,URL redirection,+PACKAGE_lighttpd-mod-redirec
 
 # Next, permit authentication.
 $(eval $(call BuildPlugin,auth,Authentication,,20))
+$(eval $(call BuildPlugin,authn_file,File-based authentication,,20))
 
 # Finally, everything else.
 $(eval $(call BuildPlugin,access,Access restrictions,,30))


### PR DESCRIPTION
Extends lighttpd build to include lib "mod_authn_file.so" as enabling the mod_auth package supplied by Turris OS fails:
root@turom:/# /usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
2018-01-24 23:24:42: (plugin.c.229) dlopen() failed for: /usr/lib/lighttpd/mod_authn_file.so Error loading shared library /usr/lib/lighttpd/mod_authn_file.so: No such file or directory
2018-01-24 23:24:42: (server.c.1231) loading plugins finally failed

As per commit made against Openwrt lighttpd package makefile here: https://github.com/openwrt/packages/pull/3565/commits/410e4ea3d1995a96cde7d73d48ffadc416cba3fd
