### PR TITLE
dhcp_host_domain_ng: fix “old” handling

### DIFF
--- a/net/resolver-conf/files/dhcp_host_domain_ng.py
+++ b/net/resolver-conf/files/dhcp_host_domain_ng.py
@@ -248,8 +248,8 @@ class DHCPv4:
             self._del_lease(hostname, ipv4)
             log("DHCP delete hostname [%s,%s,%s]" % (op, hostname, ipv4), LOG_INFO)
         elif op == "old":
-            self._del_lease(hostname, ipv4)
-            log("DHCP remove old hostname [%s,%s,%s]" % (op, hostname, ipv4), LOG_INFO)
+            self._add_lease(hostname, ipv4)
+            log("DHCP update hostname [%s,%s,%s]" % (op, hostname, ipv4), LOG_INFO)
         else:
             log("DHCP unknown update operation", LOG_WARNING)
 


### PR DESCRIPTION
From https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html:

> The arguments to the process are "add", "old" or "del", the MAC address of the host (or DUID for IPv6) , the IP address, and the hostname, if known. "add" means a lease has been created, "del" means it has been destroyed, "old" is a notification of an existing lease when dnsmasq starts or a change to MAC address or hostname of an existing lease (also, lease length or expiry and client-id, if leasefile-ro is set).

Before this commit, DHCP leases would make their way into DNS resolution, but would be removed as soon as they renew their lease (usually a few hours after obtaining the lease, which might explain why nobody noticed this bug sooner).