### PR TITLE
unbound: Enable TCP fast open

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
@@ -109,6 +109,8 @@ endef
 CONFIGURE_ARGS += \
 	--disable-gost \
 	--enable-allsymbols \
+	--enable-tfo-client \
+	--enable-tfo-server \
 	--with-ldns="$(STAGING_DIR)/usr" \
 	--with-libexpat="$(STAGING_DIR)/usr" \
 	--with-ssl="$(STAGING_DIR)/usr" \


### PR DESCRIPTION
TCP fast open can cut a whole RTT off the connection establishment
procedure to servers that support it.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>