### PR TITLE
Make the backups actually useful

### DIFF
--- a/cznic/nuci/files/backups.conf
+++ b/cznic/nuci/files/backups.conf
@@ -1,4 +1,19 @@
 package backups
 
 config generate generate
-	#list dirs "/etc/openvpn"
+        list dirs "/etc/rc.d"
+        list dirs "/etc/firewall.user"
+        list dirs "/etc/firewall.d"
+	list dirs "/etc/cron.d"
+        list dirs "/etc/crontabs"
+        list dirs "/etc/syslog-ng.conf"
+        list dirs "/etc/syslog-ng.d"
+        list dirs "/etc/ppp"
+        list dirs "/etc/pptpd.conf"
+        list dirs "/etc/passwd"        
+        list dirs "/etc/openvpn"
+        list dirs "/etc/ssl/ca"
+        list dirs "/etc/rc.local"
+        list dirs "/etc/profile"
+        list dirs "/etc/tor"
+	list dirs "/root/.ssh"


### PR DESCRIPTION
In reaction to https://forum.turris.cz/t/restoring-from-a-cloud-backup-experience/8251/4 .

There's a lot of useful stuff that's not currently being backed up. Restoring from such backup after flasing a medkit results in half-working system (especially missing firewall.user).