### PR TITLE
Fix generation of unbound.conf and forward_custom on Turris 1.0

### DIFF
--- a/net/unbound/files/unbound-init
+++ b/net/unbound/files/unbound-init
@@ -373,13 +373,11 @@ print_dns_config() {
     echo "forward-zone:">>$CONFIGFILE
     echo '	name: "."'>>$CONFIGFILE
 
-    # FIX disable forward-tls until we upgrade to openssl 1.1.0
-    echo "	forward-tls-upstream: no">>$CONFIGFILE
-    #if [ "$enable_tls" == "1" ]; then
-    #    echo "	forward-tls-upstream: yes">>$CONFIGFILE
-    #else
-    #    echo "	forward-tls-upstream: no">>$CONFIGFILE
-    #fi
+    if [ "$enable_tls" == "1" ]; then
+        echo "	forward-tls-upstream: yes">>$CONFIGFILE
+    else
+        echo "	forward-tls-upstream: no">>$CONFIGFILE
+    fi
 
     for ip in $ip_list
     do

--- a/net/unbound/files/unbound-init
+++ b/net/unbound/files/unbound-init
@@ -407,19 +407,18 @@ dns_config_load() {
     config_name="$1"
     config_file="/etc/resolver/dns_servers/${config_name}.conf"
     config_load resolver
-    ret=$(config_foreach handle_dns_config_load dns_server "$config_name")
 
-    #uci part nof found, check file
-    if [ "$?" == "1" ] && [ -f "$config_file" ]; then
+    if [ -f "$config_file" ]; then
         enable_tls="0" #set default value
         config_get net_ipv6 "common" "net_ipv6" 1
         config_get net_ipv4 "common" "net_ipv4" 1
 
         echo "loading file from ... $config_file"
         source $config_file
-        echo print_dns_config  "$name" "$description" "$enable_tls" "$port" "$ipv4" "$ipv6" "$pin_sha256" "$hostname" "$net_ipv4" "$net_ipv6"
-        print_dns_config  "$name" "$description" "$enable_tls" "$port" "$ipv4" "$ipv6" "$pin_sha256" "$hostname" "$net_ipv4" "$net_ipv6"
+        echo print_dns_config  "$name" "$description" "$enable_tls" "$port" "$ipv4" "$ipv6" "$pin_sha256" "$hostname" "$ca_file" "$net_ipv4" "$net_ipv6"
+        print_dns_config  "$name" "$description" "$enable_tls" "$port" "$ipv4" "$ipv6" "$pin_sha256" "$hostname" "$ca_file" "$net_ipv4" "$net_ipv6"
     fi
+
     #echo "ret_value_dns_load=$ret"
 }
 


### PR DESCRIPTION
Hi,
without the following fixes the generated `unbound.conf` doesn't contain set `forward_custom` entries.

I need to set `enable_tls=1` or else I get no reply from configured upstream DNS provider.

regards Petr