### PR TITLE
lighttpd-https-cert: Disable deprecated ciphers

### DIFF
--- a/net/lighttpd-https-cert/files/ssl-enable.conf
+++ b/net/lighttpd-https-cert/files/ssl-enable.conf
@@ -4,10 +4,6 @@
 # This package is not meant to be edited, it is part of package lighttpd-https-cert
 # If you need different https setup, uninstall this package and create your own configuration
 
-# As a special case in lighttpd 1.4.46 and later, if ssl.engine = "enable" in
-# the global scope and along with ssl.pemfile, then $SERVER["socket"] blocks
-# can inherit the exact global config by setting ssl.engine = "enable" and no
-# other ssl.* directives in the $SERVER["socket"] block.
 ssl.engine = "enable"
 ssl.pemfile = "/etc/lighttpd-self-signed.pem"
 ssl.use-sslv2 = "disable"

--- a/net/lighttpd-https-cert/files/ssl-enable.conf
+++ b/net/lighttpd-https-cert/files/ssl-enable.conf
@@ -6,8 +6,7 @@
 
 ssl.engine = "enable"
 ssl.pemfile = "/etc/lighttpd-self-signed.pem"
-ssl.use-sslv2 = "disable"
-ssl.use-sslv3 = "disable"
+ssl.openssl.ssl-conf-cmd = ("Protocol" => "-ALL, +TLSv1.2")
 ssl.cipher-list = "EDH+CAMELLIA:EDH+aECDSA:EECDH+aECDSA+AESGCM:EECDH+aECDSA+SHA384:EECDH+aECDSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 
 $SERVER["socket"] == ":443" {

--- a/net/lighttpd-https-cert/files/ssl-enable.conf
+++ b/net/lighttpd-https-cert/files/ssl-enable.conf
@@ -4,20 +4,22 @@
 # This package is not meant to be edited, it is part of package lighttpd-https-cert
 # If you need different https setup, uninstall this package and create your own configuration
 
+# As a special case in lighttpd 1.4.46 and later, if ssl.engine = "enable" in
+# the global scope and along with ssl.pemfile, then $SERVER["socket"] blocks
+# can inherit the exact global config by setting ssl.engine = "enable" and no
+# other ssl.* directives in the $SERVER["socket"] block.
+ssl.engine = "enable"
+ssl.pemfile = "/etc/lighttpd-self-signed.pem"
+ssl.use-sslv2 = "disable"
+ssl.use-sslv3 = "disable"
+ssl.cipher-list = "EDH+CAMELLIA:EDH+aECDSA:EECDH+aECDSA+AESGCM:EECDH+aECDSA+SHA384:EECDH+aECDSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
+
 $SERVER["socket"] == ":443" {
 	ssl.engine = "enable"
-	ssl.pemfile = "/etc/lighttpd-self-signed.pem"
-	ssl.use-sslv2 = "disable"
-	ssl.use-sslv3 = "disable"
-	ssl.cipher-list = "EDH+CAMELLIA:EDH+aECDSA:EECDH+aECDSA+AESGCM:EECDH+aECDSA+SHA384:EECDH+aECDSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 }
 
 $SERVER["socket"] == "[::]:443" {
 	ssl.engine  = "enable"
-	ssl.pemfile = "/etc/lighttpd-self-signed.pem"
-	ssl.use-sslv2 = "disable"
-	ssl.use-sslv3 = "disable"
-	ssl.cipher-list = "EDH+CAMELLIA:EDH+aECDSA:EECDH+aECDSA+AESGCM:EECDH+aECDSA+SHA384:EECDH+aECDSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 }
 
 $HTTP["scheme"] == "https" {

--- a/net/lighttpd-https-cert/files/ssl-enable.conf
+++ b/net/lighttpd-https-cert/files/ssl-enable.conf
@@ -7,11 +7,17 @@
 $SERVER["socket"] == ":443" {
 	ssl.engine = "enable"
 	ssl.pemfile = "/etc/lighttpd-self-signed.pem"
+	ssl.use-sslv2 = "disable"
+	ssl.use-sslv3 = "disable"
+	ssl.cipher-list = "EDH+CAMELLIA:EDH+aECDSA:EECDH+aECDSA+AESGCM:EECDH+aECDSA+SHA384:EECDH+aECDSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 }
 
 $SERVER["socket"] == "[::]:443" {
 	ssl.engine  = "enable"
 	ssl.pemfile = "/etc/lighttpd-self-signed.pem"
+	ssl.use-sslv2 = "disable"
+	ssl.use-sslv3 = "disable"
+	ssl.cipher-list = "EDH+CAMELLIA:EDH+aECDSA:EECDH+aECDSA+AESGCM:EECDH+aECDSA+SHA384:EECDH+aECDSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 }
 
 $HTTP["scheme"] == "https" {


### PR DESCRIPTION
Removed SSLv2, SSLv3 and insecure ciphersuites:
* 64-bit block cipher 3DES vulnerable to the SWEET32 attack (CVE-2016-2183).
* RC4 CVE-2013-2566, CVE-2015-2808
* Ciphers using less than 64 bits CVE-2015-4000
* RSA authentication with less than 1024 bit is considered weak