### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,6 @@
+ARG ARCH=x86-64
+FROM openwrtorg/rootfs:$ARCH
+
+ADD entrypoint.sh /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/.github/workflows/ci_helpers.sh
+++ b/.github/workflows/ci_helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+color_out() {
+	printf "\e[0;$1m$PKG_NAME: %s\e[0;0m\n" "$2"
+}
+
+success() {
+	color_out 32 "$1"
+}
+
+info() {
+	color_out 36 "$1"
+}
+
+err() {
+	color_out 31 "$1"
+}
+
+warn() {
+	color_out 33 "$1"
+}
+
+err_die() {
+	err "$1"
+	exit 1
+}

--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+mkdir -p /var/lock/
+
+opkg update
+
+[ -n "$CI_HELPER" ] || CI_HELPER="/ci/.github/workflows/ci_helpers.sh"
+
+for PKG in /ci/*.ipk; do
+	tar -xzOf "$PKG" ./control.tar.gz | tar xzf - ./control
+	# package name including variant
+	PKG_NAME=$(sed -ne 's#^Package: \(.*\)$#\1#p' ./control)
+	# package version without release
+	PKG_VERSION=$(sed -ne 's#^Version: \(.*\)-[0-9]*$#\1#p' ./control)
+	# package source contianing test.sh script
+	PKG_SOURCE=$(sed -ne 's#^Source: .*/\(.*\)$#\1#p' ./control)
+
+	echo "Testing package $PKG_NAME in version $PKG_VERSION from $PKG_SOURCE"
+
+	opkg install "$PKG"
+
+	export PKG_NAME PKG_VERSION CI_HELPER
+
+	TEST_SCRIPT=$(find /ci/ -name "$PKG_SOURCE" -type d)/test.sh
+
+	if [ -f "$TEST_SCRIPT" ]; then
+		echo "Use package specific test.sh"
+		if sh "$TEST_SCRIPT" "$PKG_NAME" "$PKG_VERSION"; then
+			echo "Test succesful"
+		else
+			echo "Test failed"
+			exit 1
+		fi
+	else
+		echo "Use generic test"
+	        PKG_FILES=$(opkg files "$PKG_NAME" | grep -E "/bin|/sbin|/usr/bin|/usr/sbin")
+		SUCCESS=0
+		FOUND_EXE=0
+		for FILE in $PKG_FILES; do
+			if [ -x "$FILE" ] && [ -f "$FILE" ]; then
+				FOUND_EXE=1
+				echo "Test executable $FILE"
+				for V in --version -version version -v -V; do
+					echo "Trying $FILE $V"
+					if "$FILE" "$V" 2>&1 | grep "$PKG_VERSION"; then
+						SUCCESS=1
+						break
+					fi
+				done
+
+			fi
+		done
+		if [ "$FOUND_EXE" -eq 1 ]; then
+			if [ "$SUCCESS" -eq 0 ]; then
+				echo "Generic test failed"
+				exit 1
+			else
+				echo "Test successful"
+			fi
+		else
+			echo "No executable found in package $PKG_NAME"
+		fi
+	fi
+
+	opkg remove "$PKG_NAME" --force-removal-of-dependent-packages --force-remove
+done

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -1,0 +1,94 @@
+name: Test Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Test ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - arc_arc700
+          - arm_cortex-a9_vfpv3-d16
+          - mips_24kc
+          - powerpc_464fp
+          - powerpc_8540
+        runtime_test: [false]
+        include:
+          - arch: aarch64_cortex-a53
+            runtime_test: true
+          - arch: arm_cortex-a15_neon-vfpv4
+            runtime_test: true
+          - arch: i386_pentium-mmx
+            runtime_test: true
+          - arch: x86_64
+            runtime_test: true
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Determine changed packages
+        run: |
+          # only detect packages with changed Makefiles
+          PACKAGES="$(git diff --diff-filter=d --name-only origin/master \
+            | grep -E 'Makefile$|test.sh$' | grep -Ev '/files/|/src/' \
+            | awk -F/ '{ print $(NF-1) }' | tr '\n' ' ')"
+
+          # fallback to test packages if nothing explicitly changes this is
+          # should run if other mechanics in packages.git changed
+          PACKAGES="${PACKAGES:-vim tmux bmon}"
+
+          echo "Building $PACKAGES"
+          echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Build
+        uses: openwrt/gh-action-sdk@v1
+        env:
+          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
+          FEEDNAME: packages_ci
+
+      - name: Move created packages to project dir
+        run: cp bin/packages/${{ matrix.arch }}/packages_ci/*.ipk . || true
+
+      - name: Store packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.arch}}-packages
+          path: "*.ipk"
+
+      - name: Store logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.arch}}-logs
+          path: logs/
+
+      - name: Remove logs
+        run: sudo rm -rf logs/ || true
+
+      - name: Register QEMU
+        if: ${{ matrix.runtime_test }}
+        run: |
+          sudo docker run --rm --privileged aptman/qus -s -- -p
+
+      - name: Build Docker container
+        if: ${{ matrix.runtime_test }}
+        run: |
+          docker build -t test-container --build-arg ARCH .github/workflows/
+        env:
+          ARCH: ${{ matrix.arch }}
+
+      - name: Test via Docker container
+        if: ${{ matrix.runtime_test }}
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/ci test-container

--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -1,31 +1,28 @@
 name: Test Build
 
-on:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:
-    name: Test ${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         arch:
-          - arc_arc700
           - arm_cortex-a9_vfpv3-d16
-          - mips_24kc
-          - powerpc_464fp
           - powerpc_8540
+        version:
+          - master
+          - 19.07.5
         runtime_test: [false]
         include:
           - arch: aarch64_cortex-a53
+            version:
+            - master
+            - 19.07.5
             runtime_test: true
-          - arch: arm_cortex-a15_neon-vfpv4
-            runtime_test: true
-          - arch: i386_pentium-mmx
-            runtime_test: true
-          - arch: x86_64
-            runtime_test: true
+
+    name: Target ${{ matrix.arch }} - OpenWrt ${{ matrix.version }}
 
     steps:
       - uses: actions/checkout@v2
@@ -35,42 +32,36 @@ jobs:
       - name: Determine changed packages
         run: |
           # only detect packages with changed Makefiles
-          PACKAGES="$(git diff --diff-filter=d --name-only origin/master \
+          PACKAGES="$(git diff --diff-filter=d --name-only origin/develop \
             | grep -E 'Makefile$|test.sh$' | grep -Ev '/files/|/src/' \
             | awk -F/ '{ print $(NF-1) }' | tr '\n' ' ')"
 
           # fallback to test packages if nothing explicitly changes this is
-          # should run if other mechanics in packages.git changed
-          PACKAGES="${PACKAGES:-vim tmux bmon}"
+          # should run if other mechanics changed
+          PACKAGES="${PACKAGES:-notification-system netmetr lighttpd}"
 
           echo "Building $PACKAGES"
           echo "PACKAGES=$PACKAGES" >> $GITHUB_ENV
 
-      - name: Determine branch name
-        run: |
-          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
-          echo "Building for $BRANCH"
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-
       - name: Build
         uses: openwrt/gh-action-sdk@v1
         env:
-          ARCH: ${{ matrix.arch }}-${{ env.BRANCH }}
-          FEEDNAME: packages_ci
+          ARCH: ${{ matrix.arch }}
+          FEEDNAME: turrispackages_ci
 
       - name: Move created packages to project dir
-        run: cp bin/packages/${{ matrix.arch }}/packages_ci/*.ipk . || true
+        run: cp bin/packages/${{ matrix.arch }}/turrispackages_ci/*.ipk . || true
 
       - name: Store packages
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.arch}}-packages
+          name: ${{ matrix.arch}}-${{ matrix.version }}-packages
           path: "*.ipk"
 
       - name: Store logs
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.arch}}-logs
+          name: ${{ matrix.arch}}-${{ matrix.version }}-logs
           path: logs/
 
       - name: Remove logs


### PR DESCRIPTION
# Add Github Actions
(comes from OpenWrt packages feed)

It means that we are testing just our three platforms
and one of it is even run tested in Docker. Also, it uses Docker
repositories maintainer by OpenWrt developers.

Tested platforms:
powerpc_8540 (Turris 1.x)
arm_cortex-a9_vfpv3-d16 (Turris Omnia)
aarch64_cortex-a53 (Turris MOX, Turris Shield)
- This one is run time tested in Docker

This should compile packages and upload them as artefacts, which means
that there is going to be less manual work which should lead to have
merged pull requests faster.

One minor disadvantage for now is that this compiles packages
against OpenWrt releases (stable and snapshots) without our patches, which comes
from turris-build repository and that it is tested against develop
branch from turris-os-packages.

See how it looks: https://github.com/BKPepe/turris-os-packages/actions/runs/452459339

Github Actions will be run on every push (including branches, commits)
and pull request (here on GitHub).

This requires: https://gitlab.nic.cz/turris/turris-os-packages/-/merge_requests/422 to get fixed lighttpd builds